### PR TITLE
make this more compatible with alpine

### DIFF
--- a/last_green_commit.sh
+++ b/last_green_commit.sh
@@ -3,7 +3,7 @@ DIRNAME="$(dirname $(readlink -f "$0"))"
 pushd ${DIRNAME}
 header="PRIVATE-TOKEN: ${PRIVATE_TOKEN}"
 url="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipelines?status=success&ref=${CI_COMMIT_REF_NAME}"
-commit=$(curl -H ${header}  -s ${url} | jq -r -f jq.filter)
+commit=$(curl --header "${header}"  -s "${url}" | jq -r -f jq.filter)
 echo "Last green commit is '${commit}'."
 echo ${commit} > .LAST_GREEN_COMMIT
 popd

--- a/last_green_commit.sh
+++ b/last_green_commit.sh
@@ -3,7 +3,9 @@ DIRNAME="$(dirname $(readlink -f "$0"))"
 pushd ${DIRNAME}
 header="PRIVATE-TOKEN: ${PRIVATE_TOKEN}"
 url="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/pipelines?status=success&ref=${CI_COMMIT_REF_NAME}"
-commit=$(curl --header "${header}"  -s "${url}" | jq -r -f jq.filter)
-echo "Last green commit is '${commit}'."
-echo ${commit} > .LAST_GREEN_COMMIT
+curl --header "${header}"  -s "${url}" -o tmp
+jq -r -f jq.filter < tmp > .LAST_GREEN_COMMIT
+echo "Last green commit is"
+cat .LAST_GREEN_COMMIT
+rm tmp
 popd


### PR DESCRIPTION
I'm still not 100% through the problem, but busybox in alpine seems to be doing something super funky with the subshelling. However if we use `--header` and quote the variables, it will make them "shell safer".